### PR TITLE
[FEAT] API user metrics on userStatusPage and Dashboard

### DIFF
--- a/enem_app/frontend/src/components/RequiredAuth.jsx
+++ b/enem_app/frontend/src/components/RequiredAuth.jsx
@@ -10,12 +10,13 @@ const RequireAuth = () => {
 
   // Verifica se há token válido (seja do estado ou do localStorage)
   const hasValidToken = auth?.accessToken || accessToken;
-  const hasValidRole = auth?.role && (auth.role === "USER" || auth.role === "ADMIN");
-  
-  console.log("RequireAuth - Auth:", auth);
-  console.log("RequireAuth - AccessToken:", accessToken);
-  console.log("RequireAuth - HasValidToken:", hasValidToken);
-  console.log("RequireAuth - HasValidRole:", hasValidRole);
+  const hasValidRole =
+    auth?.role && (auth.role === "USER" || auth.role === "ADMIN");
+
+  //console.log("RequireAuth - Auth:", auth);
+  //console.log("RequireAuth - AccessToken:", accessToken);
+  //console.log("RequireAuth - HasValidToken:", hasValidToken);
+  //console.log("RequireAuth - HasValidRole:", hasValidRole);
 
   // Se tem token e role válidos, permite acesso
   if (hasValidToken && hasValidRole) {

--- a/enem_app/frontend/src/components/UserStatusDashboard.jsx
+++ b/enem_app/frontend/src/components/UserStatusDashboard.jsx
@@ -8,6 +8,7 @@ import { useNavbar } from "../context/NavbarContext";
 import useAuth from "../hooks/useAuth";
 
 export default function StatusUsuario({
+  userData,
   imageProfile,
   percentage,
   StudyTime,
@@ -15,7 +16,6 @@ export default function StatusUsuario({
 }) {
   const { updateActiveIndex } = useNavbar();
   const { auth } = useAuth();
-  
   const radius = 90;
   const circunferency = 2 * Math.PI * radius;
   const dashArray = circunferency * 0.83;
@@ -52,10 +52,12 @@ export default function StatusUsuario({
               className="progress-foreground"
             />
           </svg>
-          <div className="percentage-in-circle">{percentage}xp</div>
+          <div className="percentage-in-circle">
+            {userData?.user?.xpPoints}xp
+          </div>
         </div>
-        <div
-          className="name-user">{auth?.userName || "Usuário"}</div>
+        {/* <div className="name-user">{auth?.userName || "Usuário"}</div> */}
+        <div className="name-user">{userData?.user?.name || "Usuário"}</div>
         {/* Depois definir limite de caracteres */}
         <div className="information-progress">
           <div className="information" id="info-answers">
@@ -93,28 +95,25 @@ export default function StatusUsuario({
           </div>
         </div>
         <NavLink to={"/userStatusPage"}>
-          <button 
+          <button
             className="button-user-status"
             onClick={() => updateActiveIndex(0)}
           >
-            <BsPerson color="#fff" size={"2rem"}            
-            />
+            <BsPerson color="#fff" size={"2rem"} />
             <h1>Ver perfil</h1>
           </button>
         </NavLink>
 
         <NavLink to="/flashCardPage">
-          <button 
+          <button
             className="button-user-status"
             onClick={() => updateActiveIndex(2)}
           >
-            < PiCards color="#fff" size={"2rem"}/>           
+            <PiCards color="#fff" size={"2rem"} />
             <h1>FlashCards</h1>
           </button>
         </NavLink>
-
       </div>
-      
     </div>
   );
 }

--- a/enem_app/frontend/src/pages/Dashboard.jsx
+++ b/enem_app/frontend/src/pages/Dashboard.jsx
@@ -10,6 +10,9 @@ import UserStatusDashboard from "../components/UserStatusDashboard";
 import CardSkillsDashboard from "../components/CardSkillsDashboard";
 import useAuth from "../hooks/useAuth";
 
+import { userStatusFullAPI } from "../services/userStatusServices";
+import { useEffect, useState } from "react";
+
 // Importe sua imagem local aqui (ajuste o caminho conforme sua estrutura)
 import educationImg from "../assets/undraw_blogging_38kl.svg";
 // import educationImg2 from "../assets/undraw_books_wxzz.svg"
@@ -17,6 +20,24 @@ import educationImg from "../assets/undraw_blogging_38kl.svg";
 export default function Dashboard() {
   const { auth } = useAuth();
   const id = "LC";
+
+  const { accessToken } = useAuth();
+  const [userData, setUserdata] = useState([]);
+
+  // API FOR THE USER INFORMATION IN THE DASHBOARD
+  async function getUserData() {
+    try {
+      const response = await userStatusFullAPI(accessToken);
+      setUserdata(response.data);
+      console.log("RESPONSE USER DATA: ", response.data);
+    } catch (err) {
+      console.log("ERRO: ", err);
+    }
+  }
+
+  useEffect(() => {
+    getUserData();
+  }, []);
 
   // Função para obter saudação baseada no horário e nome do usuário
   const getGreeting = (userName) => {
@@ -27,19 +48,19 @@ export default function Dashboard() {
       return {
         greeting: `Bom dia, ${name}!`,
         message: "Que tal começar o dia estudando para o ENEM?",
-        period: "morning"
+        period: "morning",
       };
     } else if (currentHour >= 12 && currentHour < 18) {
       return {
         greeting: `Boa tarde, ${name}!`,
         message: "Continue firme nos estudos para o ENEM!",
-        period: "afternoon"
+        period: "afternoon",
       };
     } else {
       return {
         greeting: `Boa noite, ${name}!`,
         message: "Dedique um tempo aos estudos antes de descansar!",
-        period: "night"
+        period: "night",
       };
     }
   };
@@ -55,13 +76,14 @@ export default function Dashboard() {
               <h2>{greetingData.greeting}</h2>
               <p>{greetingData.message}</p>
               <p className="banner-subtitle">
-                Acelere seus estudos com nosso método exclusivo preparatório para o ENEM.
+                Acelere seus estudos com nosso método exclusivo preparatório
+                para o ENEM.
               </p>
             </div>
             <div className="banner-image">
               {/* OPÇÃO 1: Usando a imagem local importada */}
               {/* <img src={educationImg2} alt="Ilustração de educação"/> */}
-              <img id="book" src={educationImg} alt="Ilustração de educação"/>
+              <img id="book" src={educationImg} alt="Ilustração de educação" />
 
               {/* OPÇÃO 2: URL externa temporária (comentada) */}
               {/* <img
@@ -81,7 +103,9 @@ export default function Dashboard() {
             <NavLink to={`/SkillPage/LC`}>
               <CardSkillsDashboard
                 title={"Linguagens, Códigos e suas Tecnologias"}
-                description={"Envolve interpretação de textos, gramática, literatura, artes, educação física e língua estrangeira (inglês ou espanhol)."}
+                description={
+                  "Envolve interpretação de textos, gramática, literatura, artes, educação física e língua estrangeira (inglês ou espanhol)."
+                }
                 icon={<FaBookOpen />}
               />
             </NavLink>
@@ -89,15 +113,19 @@ export default function Dashboard() {
             <NavLink to="/SkillPage/MT">
               <CardSkillsDashboard
                 title={"Matemática e suas Tecnologias"}
-                description={"Abrange resolução de problemas, álgebra, geometria, estatística, raciocínio lógico e funções."}
+                description={
+                  "Abrange resolução de problemas, álgebra, geometria, estatística, raciocínio lógico e funções."
+                }
                 icon={<TbMathFunction />}
               />
             </NavLink>
 
             <NavLink to="/SkillPage/CN">
-              <CardSkillsDashboard 
+              <CardSkillsDashboard
                 title={"Ciências da Natureza e suas Tecnologias"}
-                description={"Inclui física, química e biologia, com foco em fenômenos naturais, experimentos e aplicações do conhecimento científico."}
+                description={
+                  "Inclui física, química e biologia, com foco em fenômenos naturais, experimentos e aplicações do conhecimento científico."
+                }
                 icon={<GiMicroscope />}
               />
             </NavLink>
@@ -105,7 +133,9 @@ export default function Dashboard() {
             <NavLink to="/SkillPage/CH">
               <CardSkillsDashboard
                 title={"Ciências Humanas e suas Tecnologias"}
-                description={"Trata de história, geografia, filosofia e sociologia, analisando fatos históricos, culturais, sociais e políticos."}
+                description={
+                  "Trata de história, geografia, filosofia e sociologia, analisando fatos históricos, culturais, sociais e políticos."
+                }
                 icon={<FaGlobeAmericas />}
               />
             </NavLink>
@@ -114,7 +144,13 @@ export default function Dashboard() {
       </div>
 
       <div className="upperCards">
-              <UserStatusDashboard imageProfile={"/imagemdeperfil.png"} StudyTime={20} numberofcorrectanswers={9} percentage={10}/>
+        <UserStatusDashboard
+          userData={userData}
+          imageProfile={"/imagemdeperfil.png"}
+          StudyTime={20}
+          numberofcorrectanswers={9}
+          percentage={10}
+        />
       </div>
     </div>
   );

--- a/enem_app/frontend/src/pages/UserStatusPage.jsx
+++ b/enem_app/frontend/src/pages/UserStatusPage.jsx
@@ -1,32 +1,47 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import "../styles/pages/userStatusPage.sass";
 
 import useAuth from "../hooks/useAuth";
-import { userStatusAPI } from "../services/userStatusServices";
+import { userStatusFullAPI } from "../services/userStatusServices";
 
 export default function UserStatusPage() {
   const { accessToken } = useAuth();
   const [userData, setUserdata] = useState([]);
+  const [userMetrics, setUserMetrics] = useState([]);
+  const [loading, setLoading] = useState(true);
 
   async function getUserData() {
     try {
-      const response = await userStatusAPI(accessToken);
-      setUserdata(response.data);
-
+      const response = await userStatusFullAPI(accessToken);
+      setUserdata(response.data.user);
+      setUserMetrics(response.data.metrics);
+      setLoading(false);
       //console.log("RESPONSE USER DATA: ", response.data);
+      console.log("METRICS: ", response.data.metrics);
+      console.log("USER DATA: ", response.data.user);
     } catch (err) {
       console.log("ERRO: ", err);
     }
   }
 
-  useState(() => {
+  useEffect(() => {
     getUserData();
   }, []);
+
+  if (loading) {
+    return <div>Loading</div>;
+  }
 
   return (
     <div className="container-usersatus">
       <h1>USER STATUS PAGE</h1>
-      {userData ? <p>User name: {userData.name}</p> : <p>Loading....</p>}
+      <p>User: {userData.name}</p>
+
+      <p>Metrics</p>
+      <p>Current Level: {userMetrics.currentLevel}</p>
+      <p>FlashcardCount: {userMetrics.flashcardCount}</p>
+      <p>Top Area: {userMetrics.topArea.areaId}</p>
+      <p>Total Xp{userMetrics.totalXp}</p>
     </div>
   );
 }

--- a/enem_app/frontend/src/services/userStatusServices.js
+++ b/enem_app/frontend/src/services/userStatusServices.js
@@ -1,10 +1,22 @@
 import axios from "../api/axios";
 
 const USERDATA_URL = "/api/user/profile";
+const USERDATAFULL_URL = "/api/user/profile/full";
 
 // FOR INFO ON THE USER PROFILE ---------------------------------------------------------
 export async function userStatusAPI(accessToken) {
   const response = await axios.get(USERDATA_URL, {
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+      "Content-Type": "application/json",
+    },
+  });
+  return response;
+}
+
+// FOR USER FULL + METRICS INFORMATION ------------------------------------------------
+export async function userStatusFullAPI(accessToken) {
+  const response = await axios.get(USERDATAFULL_URL, {
     headers: {
       Authorization: `Bearer ${accessToken}`,
       "Content-Type": "application/json",


### PR DESCRIPTION
Added the /user/profile/full API 

Was implemented 

 - userStatusPage 
   - Wil recive the full metrics from the API, separated in two states 
   - userData for the base user information
   - userMetrics for the full user metrics information

 - Dashboard for the UserStatusDashboard components.
The API call was implemented in the Dashboard component to follow the UserStatusDashboard reciving structure from props.
   - userData is passed fully and can be accessed by using userData?.user? or userData?.metrics?
   - Only the name and Xp has been updated to recive data from the API

